### PR TITLE
Add :mapper_class option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -85,7 +85,8 @@ the host mapper itself, but may be defined manually.
 
 The following options may be used when mounting a mapper:
 
-* `:mapper_class` Specifies mapper class if it cannot be determined from mounting itself
+* `:mapper_class` Specifies mapper class if it cannot be determined from mounting itself.
+* `:mapper_class_name` Alternate string form of class name instead of mapper_class.
 * `:target` Allows to manually specify target for the new mapper. May be oject or lambda
             with arity of one that accepts host mapper target as argument. Comes in handy
             when target cannot be obviously detected or requires additional setup:

--- a/lib/flat_map/model_mapper.rb
+++ b/lib/flat_map/model_mapper.rb
@@ -77,7 +77,8 @@ module FlatMap
   #
   # The following options may be used when mounting a mapper:
   # [<tt>:mapper_class</tt>] Specifies mapper class if it cannot be determined from mounting itself
-  # [<tt>:target</tt>] Allows to manually specify target for the new mapper. May be oject or lambda
+  # [<tt>:mapper_class_name</tt>] Alternate string form of class name instead of mapper_class.
+  # [<tt>:target</tt>] Allows to manually specify target for the new mapper. May be an object or lambda
   #                    with arity of one that accepts host mapper target as argument. Comes in handy
   #                    when target cannot be obviously detected or requires additional setup:
   #                    <tt>mount :title, :target => lambda{ |customer| customer.title_customers.build.build_title }</tt>

--- a/lib/flat_map/model_mapper/persistence.rb
+++ b/lib/flat_map/model_mapper/persistence.rb
@@ -1,5 +1,5 @@
 module FlatMap
-  # This module enhances and modifies original FlatMap::OpenMapper::Persistance
+  # This module enhances and modifies original FlatMap::OpenMapper::Persistence
   # functionality for ActiveRecord models as targets.
   module ModelMapper::Persistence
     extend ActiveSupport::Concern

--- a/lib/flat_map/open_mapper/factory.rb
+++ b/lib/flat_map/open_mapper/factory.rb
@@ -52,6 +52,7 @@ module FlatMap
         case
         when traited?        then @identifier
         when @options[:open] then open_mapper_class
+        when @options[:mapper_class] then @options[:mapper_class]
         else
           class_name = @options[:mapper_class_name] || "#{name.to_s.camelize}Mapper"
           class_name.constantize

--- a/spec/flat_map/mapper/factory_spec.rb
+++ b/spec/flat_map/mapper/factory_spec.rb
@@ -51,6 +51,14 @@ module FlatMap
           mount_factory.mapper_class.should == ::SpecMountMapper
         end
 
+        it "should be able to fetch class from mapper_class" do
+          factory = OpenMapper::Factory.new(
+                      :spec_mount,
+                      :mapper_class => FlatMap::OpenMapper::Factory::SpecMountMapper
+                    )
+          factory.mapper_class.should == ::FlatMap::OpenMapper::Factory::SpecMountMapper
+        end
+
         it "should use options if specified" do
           factory = OpenMapper::Factory.new(
                       :spec_mount,


### PR DESCRIPTION
Allows the flexibility to specify the class itself.

```
Finished in 0.21101 seconds
159 examples, 0 failures
```
