### PR TITLE
Support Ruby 3.1

### DIFF
--- a/lib/flat_map/errors.rb
+++ b/lib/flat_map/errors.rb
@@ -49,7 +49,7 @@ module FlatMap
     end
 
     # Overridden to add suffixing support for mappings of mappers with name suffix
-    def add(attr, *args)
+    def add(attr, type, **options)
       attr = :"#{attr}_#{@base.suffix}" if attr != :base && @base.suffixed?
       super
     end

--- a/lib/flat_map/open_mapper.rb
+++ b/lib/flat_map/open_mapper.rb
@@ -55,13 +55,13 @@ module FlatMap
     # @param [Object] target Target of mapping
     # @param [*Symbol] traits List of traits
     # @raise [FlatMap::Mapper::NoTargetError]
-    def initialize(target, *traits)
+    def initialize(target, *traits, &block)
       raise NoTargetError.new(self.class) unless target
 
       @target, @traits = target, traits
 
       if block_given?
-        singleton_class.trait :extension, &Proc.new
+        singleton_class.trait :extension, &block
       end
     end
 

--- a/spec/flat_map/mapper/mapping_spec.rb
+++ b/spec/flat_map/mapper/mapping_spec.rb
@@ -35,10 +35,10 @@ module FlatMap
           with({:attr_a => :attr_a, :mapped_attr_b => :attr_b}, {:writer => false}).
           and_call_original
         expect(Mapping::Factory).to receive(:new).
-                         with(:attr_a, :attr_a, :writer => false).
+                         with(:attr_a, :attr_a, { :writer => false }).
                          and_call_original
         expect(Mapping::Factory).to receive(:new).
-                         with(:mapped_attr_b, :attr_b, :writer => false).
+                         with(:mapped_attr_b, :attr_b, { :writer => false }).
                          and_call_original
 
         MappingSpec::EmptyMapper.class_eval do

--- a/spec/flat_map/mapper/mounting_spec.rb
+++ b/spec/flat_map/mapper/mounting_spec.rb
@@ -76,7 +76,7 @@ module FlatMap
     context 'defining mountings' do
       it "should use Factory for defining mappings" do
         expect(Mapper::Factory).to receive(:new).
-                        with(:foo, :mapper_class_name => 'FooMapper').
+                        with(:foo, { :mapper_class_name => 'FooMapper' }).
                         and_call_original
 
         expect{ MountingSpec::EmptyMapper.mount(:foo, :mapper_class_name => 'FooMapper') }.


### PR DESCRIPTION
Fixes breaking change- Using Proc.new to implicitly capture a passed block was removed from Ruby 3.0.
Updates Errors::add to match ActiveModel's updated definition.
Updates specs to expect options hash instead of keyword args.

[Rails 5 Errors::add](https://api.rubyonrails.org/v5.2.8.1/classes/ActiveModel/Errors.html#method-i-add)
[Rails 6 Errors::add](https://api.rubyonrails.org/v6.1.6.1/classes/ActiveModel/Errors.html#method-i-add)
